### PR TITLE
php upstream tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+# Optional backing services for PHP PHPT runs (mysqli, pgsql, PDO, etc.).
+# Start before compat-tests:
+#   docker compose up -d
+# Then run with service env merged into the run-tests child process:
+#   python3 main.py run-php --wasmer-bin ~/.wasmer/bin/wasmer --service-env
+#
+# Ports are published on the host so Wasmer PHP (still a host process) can
+# reach MySQL and Postgres via 127.0.0.1.
+
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: compat_root
+      MYSQL_DATABASE: test
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-pcompat_root"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: compat_postgres
+      POSTGRES_DB: test
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d test"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/main.py
+++ b/main.py
@@ -15,17 +15,31 @@ import threading
 from datetime import datetime, timezone
 from typing import Any
 
+from php_upstream import (
+    phpt_inventory,
+    php_loaded_extensions,
+    php_package_version,
+    php_source_version,
+    php_wasmer_runtime_probe,
+    run_php_debug,
+    run_php_upstream,
+)
 from python_upstream import append_log, run_python_debug, run_python_upstream
 
 # TODO: We should probably take it automatically from the package via:
 #       wasmer run --net python/python -- -c 'import sys; print(getattr(sys, "_git", None))'
 DEFAULT_CPYTHON_REPO = "https://github.com/wasix-org/cpython.git"
 DEFAULT_CPYTHON_COMMIT = "e3245fc95e570ac823deb50689041bc1f81d6b27"
+DEFAULT_PHP_REPO = "https://github.com/wasix-org/php.git"
+DEFAULT_PHP_REF = "v8.3.2102"
+DEFAULT_PHP_COMMIT = "6dd6dd1c7e409b8e9dcba8a8d6f9b7b5f944cc9e"
+DEFAULT_PHP_PACKAGE = "php/php-64@8.3.2102"
 DEFAULT_TIMEOUT = 600
+DEFAULT_PHP_TIMEOUT = 60
 DEFAULT_LOG_FILE = "test.log"
 RETEST_TIMEOUT = 300
 RETEST_RUNS = 3
-RESULT_STATUSES = ("PASS", "FAIL", "SKIP", "TIMEOUT", "FLAKY")
+RESULT_STATUSES = ("PASS", "FAIL", "SKIP", "TIMEOUT", "FLAKY", "BORK", "WARN", "LEAK", "XFAIL", "XLEAK")
 OK_RE = re.compile(r"^OK\b", re.MULTILINE)
 FAILED_RE = re.compile(r"^FAILED \((.+)\)", re.MULTILINE)
 
@@ -275,6 +289,18 @@ def ensure_cpython_checkout(work_dir: Path) -> Path:
     return checkout
 
 
+def ensure_php_checkout(work_dir: Path) -> Path:
+    cache_root = work_dir / "php"
+    safe = DEFAULT_PHP_COMMIT
+    checkout = cache_root / safe
+    cache_root.mkdir(parents=True, exist_ok=True)
+    if not (checkout / ".git").exists():
+        run(["git", "clone", "--depth", "1", "--branch", DEFAULT_PHP_REF, DEFAULT_PHP_REPO, str(checkout)])
+    run(["git", "fetch", "--depth", "1", "origin", DEFAULT_PHP_COMMIT], cwd=checkout)
+    run(["git", "checkout", "-B", "compat-tests-php", "FETCH_HEAD"], cwd=checkout)
+    return checkout
+
+
 def patch_faulthandler_workarounds(testdir: Path) -> None:
     # Temporary workaround: child Python startup with -X faulthandler is still
     # blocked by wasix-libc sigaltstack(). Remove these rewrites once libc is fixed.
@@ -512,6 +538,152 @@ def run_python_suite(args: argparse.Namespace) -> int:
     return 0
 
 
+def run_php_suite(args: argparse.Namespace) -> int:
+    started_at = now_utc()
+    output_dir = Path.cwd()
+    work_dir = output_dir / ".work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    php_checkout = ensure_php_checkout(work_dir)
+    php_work_dir = work_dir / "php-runner"
+    php_work_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / DEFAULT_LOG_FILE
+
+    wasmer_checkout: Path | None = None
+    prebuilt = None
+    if args.wasmer_bin:
+        wasmer_bin = Path(args.wasmer_bin).resolve()
+        if not wasmer_bin.exists():
+            raise SystemExit(f"Wasmer binary not found: {wasmer_bin}")
+        print(f"Using local Wasmer binary at {wasmer_bin}", flush=True)
+        wasmer_ref, wasmer_branch, wasmer_commit = resolve_local_wasmer_identity(args, wasmer_bin)
+    else:
+        if not args.wasmer_checkout and args.wasmer_ref == "main":
+            prebuilt = try_download_prebuilt_main_wasmer(work_dir)
+        if prebuilt is not None:
+            wasmer_bin, wasmer_commit = prebuilt
+            wasmer_ref = args.wasmer_ref
+            wasmer_branch = args.wasmer_ref
+            print(f"Using prebuilt Wasmer main artifact at {wasmer_bin}", flush=True)
+        else:
+            wasmer_checkout = resolve_wasmer_checkout(args, work_dir)
+            print(f"Building Wasmer from source at {wasmer_checkout}", flush=True)
+            run(["cargo", "build", "-p", "wasmer-cli", "--features", "llvm", "--release"], cwd=wasmer_checkout)
+            wasmer_bin = wasmer_checkout / "target" / "release" / "wasmer"
+            wasmer_ref = args.wasmer_ref
+            wasmer_branch = args.wasmer_ref
+            wasmer_commit = git_head_commit(wasmer_checkout)
+
+    enable_net = not args.no_net
+    source_version = php_source_version(php_checkout)
+    package_version = php_package_version(
+        wasmer_bin=str(wasmer_bin),
+        php_package=args.php_package,
+        enable_net=enable_net,
+    )
+    runtime_probe = php_wasmer_runtime_probe(
+        wasmer_bin=str(wasmer_bin),
+        php_package=args.php_package,
+        enable_net=enable_net,
+    )
+    if runtime_probe.get("runs_as_root"):
+        print(
+            "Note: Wasmer PHP reports posix_geteuid()==0; some upstream tests skip as 'root'. "
+            "See metadata.php.runtime_probe.",
+            flush=True,
+        )
+    if source_version != "unknown" and package_version != "unknown" and source_version != package_version:
+        print(
+            f"Warning: PHP source checkout is {source_version}, but {args.php_package} reports {package_version}",
+            flush=True,
+        )
+
+    if args.debug_test:
+        proc = run_php_debug(
+            wasmer_bin=str(wasmer_bin),
+            php_package=args.php_package,
+            php_cgi_package=args.php_cgi_package,
+            phpdbg_package=args.phpdbg_package,
+            no_php_cgi_shim=args.no_php_cgi_shim,
+            source_root=php_checkout,
+            work_dir=php_work_dir,
+            test_name=args.debug_test,
+            timeout=args.timeout,
+            enable_net=enable_net,
+            offline=args.offline,
+            service_env=args.service_env,
+        )
+        print(proc.stdout, end="")
+        print(proc.stderr, end="")
+        return 0 if proc.returncode == 0 else proc.returncode
+
+    write_text(log_path, "")
+    status = run_php_upstream(
+        wasmer_bin=str(wasmer_bin),
+        php_package=args.php_package,
+        php_cgi_package=args.php_cgi_package,
+        phpdbg_package=args.phpdbg_package,
+        no_php_cgi_shim=args.no_php_cgi_shim,
+        source_root=php_checkout,
+        work_dir=php_work_dir,
+        timeout=args.timeout,
+        jobs=args.jobs,
+        enable_net=enable_net,
+        offline=args.offline,
+        log_path=log_path,
+        service_env=args.service_env,
+    )
+    if not status:
+        raise SystemExit("PHP upstream run did not produce any test statuses")
+
+    inventory = phpt_inventory(php_checkout)
+    loaded_extensions = php_loaded_extensions(
+        wasmer_bin=str(wasmer_bin),
+        php_package=args.php_package,
+        enable_net=enable_net,
+    )
+
+    write_json(output_dir / "status.json", status)
+    metadata = {
+        "language": "php",
+        "wasmer": {
+            "ref": wasmer_ref,
+            "branch": wasmer_branch,
+            "commit": wasmer_commit,
+        },
+        "php": {
+            "repo": DEFAULT_PHP_REPO,
+            "ref": DEFAULT_PHP_REF,
+            "commit": DEFAULT_PHP_COMMIT,
+            "source_version": source_version,
+            "package": args.php_package,
+            "package_version": package_version,
+            "loaded_extensions": loaded_extensions,
+            "runtime_probe": runtime_probe,
+            "phpt_total": sum(inventory.values()),
+            "phpt_inventory": inventory,
+        },
+        "config": {
+            "timeout_seconds": args.timeout,
+            "debug_test": args.debug_test,
+            "jobs": args.jobs,
+            "offline": args.offline,
+            "net": enable_net,
+            "php_cgi_package": args.php_cgi_package,
+            "phpdbg_package": args.phpdbg_package,
+            "no_php_cgi_shim": args.no_php_cgi_shim,
+            "service_env": args.service_env,
+        },
+        "run": {
+            "started_at": started_at,
+            "finished_at": now_utc(),
+        },
+        "counts": counts_from_status(status),
+    }
+    write_json(output_dir / "metadata.json", metadata)
+    return 0
+
+
 def compare_statuses(baseline: dict[str, str], candidate: dict[str, str]) -> dict:
     baseline_counts = counts_from_status(baseline)
     candidate_counts = counts_from_status(candidate)
@@ -579,6 +751,19 @@ def result_label(result: dict) -> str:
     return "NO_CHANGE"
 
 
+def metadata_language(meta: dict[str, Any], default: str = "Python") -> str:
+    language = str(meta.get("language") or "").strip().lower()
+    if language == "php" or ("php" in meta and "python" not in meta):
+        return "PHP"
+    if language == "python" or "python" in meta:
+        return "Python"
+    return default
+
+
+def metadata_language_key(meta: dict[str, Any]) -> str:
+    return metadata_language(meta).lower()
+
+
 def render_summary_text(
     comparison: dict[str, Any],
     baseline_meta: dict[str, Any],
@@ -626,13 +811,14 @@ def render_comment(args: argparse.Namespace) -> int:
     comparison = load_json(Path(args.comparison))
     baseline_meta = load_json(Path(args.baseline_metadata))
     candidate_meta = load_json(Path(args.candidate_metadata))
+    language = args.language or metadata_language(candidate_meta)
     body = render_summary_text(
         comparison,
         baseline_meta,
         candidate_meta,
         results_repo=args.results_repo,
         results_commit=args.results_commit,
-        language="Python",
+        language=language,
     )
     if args.output:
         write_text(Path(args.output), body)
@@ -648,9 +834,10 @@ def prepare_pr_comment(args: argparse.Namespace) -> int:
 
     expected = (args.expected_wasmer_sha or "").strip()
     actual = candidate_meta.get("wasmer", {}).get("commit", "")
+    language = args.language or metadata_language(candidate_meta)
     if expected and actual != expected:
         body = (
-            "Python upstream result: ERROR\n\n"
+            f"{language} upstream result: ERROR\n\n"
             "compat-tests completed, but the published snapshot does not match the expected Wasmer SHA.\n\n"
             "More info:\n"
             f"- expected Wasmer SHA: `{expected}`\n"
@@ -665,7 +852,7 @@ def prepare_pr_comment(args: argparse.Namespace) -> int:
             candidate_meta,
             results_repo=args.results_repo,
             results_commit=args.results_commit,
-            language="Python",
+            language=language,
         ).rstrip()
         body += (
             "\n\nMore info:\n"
@@ -682,7 +869,8 @@ def prepare_pr_comment(args: argparse.Namespace) -> int:
     return 0
 
 
-def make_regression_issue_title(candidate_meta: dict[str, Any], language: str = "Python") -> str:
+def make_regression_issue_title(candidate_meta: dict[str, Any], language: str | None = None) -> str:
+    language = language or metadata_language(candidate_meta)
     branch = candidate_meta["wasmer"]["branch"]
     commit = candidate_meta["wasmer"]["commit"][:7]
     return f"{language} upstream regressions on {branch} @ {commit}"
@@ -696,6 +884,7 @@ def create_regression_issue(args: argparse.Namespace) -> int:
 
     baseline_meta = load_json(Path(args.baseline_metadata))
     candidate_meta = load_json(Path(args.candidate_metadata))
+    language = args.language or metadata_language(candidate_meta)
     repo = Path(args.repo).resolve() if args.repo else None
     results_commit = git_head_commit(repo) if repo and (repo / ".git").exists() else None
 
@@ -705,12 +894,12 @@ def create_regression_issue(args: argparse.Namespace) -> int:
         candidate_meta,
         results_repo=args.results_repo,
         results_commit=results_commit,
-        language="Python",
+        language=language,
     )
     if args.run_url:
         body += f"\nWorkflow run:\n- {args.run_url}\n"
 
-    title = make_regression_issue_title(candidate_meta, language="Python")
+    title = make_regression_issue_title(candidate_meta, language=language)
     body_file = (repo or Path.cwd()) / ".git" / "compat-tests-issue-body.txt" if repo else Path(".git/compat-tests-issue-body.txt")
     write_text(body_file, body)
     proc = run_capture(
@@ -801,9 +990,11 @@ def publish_snapshot(args: argparse.Namespace) -> int:
 
     branch_status = git_file_json(repo, "HEAD", "status.json")
     branch_metadata = git_file_json(repo, "HEAD", "metadata.json")
+    language_key = metadata_language_key(metadata)
     same_identity = (
-        branch_metadata.get("wasmer", {}) == metadata.get("wasmer", {})
-        and branch_metadata.get("python", {}) == metadata.get("python", {})
+        metadata_language(branch_metadata, metadata_language(metadata)) == metadata_language(metadata)
+        and branch_metadata.get("wasmer", {}) == metadata.get("wasmer", {})
+        and branch_metadata.get(language_key, {}) == metadata.get(language_key, {})
         and branch_metadata.get("config", {}) == metadata.get("config", {})
     )
     if branch_status == status and same_identity:
@@ -811,7 +1002,8 @@ def publish_snapshot(args: argparse.Namespace) -> int:
         print(git_head_commit(repo), flush=True)
         return 0
 
-    summary_text = render_summary_text(comparison, compare_meta, metadata, language="Python")
+    language = metadata_language(metadata)
+    summary_text = render_summary_text(comparison, compare_meta, metadata, language=language)
     write_json(repo / "status.json", status)
     write_json(repo / "metadata.json", metadata)
 
@@ -842,6 +1034,39 @@ def build_parser() -> argparse.ArgumentParser:
     run_python.add_argument("--debug-test")
     run_python.set_defaults(func=run_python_suite)
 
+    run_php = sub.add_parser("run-php", help="Run the upstream PHP PHPT suite against a Wasmer checkout")
+    run_php.add_argument("--wasmer-ref", default="main")
+    run_php.add_argument("--wasmer-bin")
+    run_php.add_argument("--wasmer-checkout")
+    run_php.add_argument("--timeout", type=int, default=DEFAULT_PHP_TIMEOUT, help="Per-test PHPT timeout in seconds")
+    run_php.add_argument("--jobs", type=int, default=worker_count(), help="Parallel PHPT workers for run-tests.php")
+    run_php.add_argument("--php-package", default=DEFAULT_PHP_PACKAGE)
+    run_php.add_argument(
+        "--php-cgi-package",
+        default=None,
+        help="Wasmer package for the CGI shim (default: same as --php-package). "
+        "Unless --no-php-cgi-shim is set, compat-tests writes php-wasmer-cgi and sets TEST_PHP_CGI_EXECUTABLE.",
+    )
+    run_php.add_argument(
+        "--phpdbg-package",
+        default=None,
+        help="Optional Wasmer package that provides phpdbg; if unset, phpdbg PHPTs stay skipped.",
+    )
+    run_php.add_argument(
+        "--no-php-cgi-shim",
+        action="store_true",
+        help="Do not set TEST_PHP_CGI_EXECUTABLE (upstream skips CGI sections).",
+    )
+    run_php.add_argument(
+        "--service-env",
+        action="store_true",
+        help="Merge MYSQL_* / PGSQL_TEST_CONNSTR defaults matching docker-compose.yml (host 127.0.0.1).",
+    )
+    run_php.add_argument("--offline", action="store_true", help="Pass --offline to run-tests.php")
+    run_php.add_argument("--no-net", action="store_true", help="Do not pass --net to wasmer run")
+    run_php.add_argument("--debug-test", help="Run one .phpt path, relative to the PHP checkout or absolute")
+    run_php.set_defaults(func=run_php_suite)
+
     compare = sub.add_parser("compare-status", help="Compare two status.json snapshots")
     compare.add_argument("--baseline", required=True)
     compare.add_argument("--candidate", required=True)
@@ -854,6 +1079,7 @@ def build_parser() -> argparse.ArgumentParser:
     comment.add_argument("--candidate-metadata", required=True)
     comment.add_argument("--results-repo")
     comment.add_argument("--results-commit")
+    comment.add_argument("--language")
     comment.add_argument("--output")
     comment.set_defaults(func=render_comment)
 
@@ -866,6 +1092,7 @@ def build_parser() -> argparse.ArgumentParser:
     pr_comment.add_argument("--run-url", required=True)
     pr_comment.add_argument("--log-artifact-url", required=True)
     pr_comment.add_argument("--expected-wasmer-sha")
+    pr_comment.add_argument("--language")
     pr_comment.add_argument("--output")
     pr_comment.set_defaults(func=prepare_pr_comment)
 
@@ -886,6 +1113,7 @@ def build_parser() -> argparse.ArgumentParser:
     issue.add_argument("--candidate-metadata", required=True)
     issue.add_argument("--results-repo")
     issue.add_argument("--run-url")
+    issue.add_argument("--language")
     issue.set_defaults(func=create_regression_issue)
 
     return parser

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from php_upstream import (
     php_package_version,
     php_source_version,
     php_wasmer_runtime_probe,
+    resolve_host_php_cgi,
     run_php_debug,
     run_php_upstream,
 )
@@ -298,7 +299,45 @@ def ensure_php_checkout(work_dir: Path) -> Path:
         run(["git", "clone", "--depth", "1", "--branch", DEFAULT_PHP_REF, DEFAULT_PHP_REPO, str(checkout)])
     run(["git", "fetch", "--depth", "1", "origin", DEFAULT_PHP_COMMIT], cwd=checkout)
     run(["git", "checkout", "-B", "compat-tests-php", "FETCH_HEAD"], cwd=checkout)
+    patch_php_runtests_worker_putenv(checkout)
     return checkout
+
+
+def patch_php_runtests_worker_putenv(php_checkout: Path) -> None:
+    """Upstream workers restore $GLOBALS['environment'] but not getenv(); SKIPIF uses getenv."""
+    path = php_checkout / "run-tests.php"
+    text = path.read_text()
+    marker = "compat-tests: sync getenv() for workers"
+    if marker in text:
+        return
+    needle = """    foreach ($greeting["GLOBALS"] as $var => $value) {
+        if ($var !== "workerID" && $var !== "workerSock" && $var !== "GLOBALS") {
+            $GLOBALS[$var] = $value;
+        }
+    }
+    foreach ($greeting["constants"] as $const => $value) {
+        define($const, $value);
+    }"""
+    insert = """    foreach ($greeting["GLOBALS"] as $var => $value) {
+        if ($var !== "workerID" && $var !== "workerSock" && $var !== "GLOBALS") {
+            $GLOBALS[$var] = $value;
+        }
+    }
+    // compat-tests: sync getenv() for workers (TEST_PHP_EXECUTABLE_ESCAPED etc. for SKIPIF).
+    if (!empty($GLOBALS['environment']) && is_array($GLOBALS['environment'])) {
+        foreach ($GLOBALS['environment'] as $__ct_k => $__ct_v) {
+            if (is_string($__ct_k) && (is_string($__ct_v) || is_int($__ct_v) || is_float($__ct_v))) {
+                putenv($__ct_k . '=' . $__ct_v);
+            }
+        }
+    }
+    foreach ($greeting["constants"] as $const => $value) {
+        define($const, $value);
+    }"""
+    if needle not in text:
+        print(f"Warning: compat-tests could not patch run-tests.php (marker block missing): {path}", flush=True)
+        return
+    path.write_text(text.replace(needle, insert, 1))
 
 
 def patch_faulthandler_workarounds(testdir: Path) -> None:
@@ -592,6 +631,10 @@ def run_php_suite(args: argparse.Namespace) -> int:
             "See metadata.php.runtime_probe.",
             flush=True,
         )
+    if not args.no_host_php_cgi and not args.no_php_cgi_shim:
+        hc = resolve_host_php_cgi()
+        if hc and args.php_cgi_package is None:
+            print(f"Using host php-cgi for CGI sections: {hc}", flush=True)
     if source_version != "unknown" and package_version != "unknown" and source_version != package_version:
         print(
             f"Warning: PHP source checkout is {source_version}, but {args.php_package} reports {package_version}",
@@ -612,6 +655,7 @@ def run_php_suite(args: argparse.Namespace) -> int:
             enable_net=enable_net,
             offline=args.offline,
             service_env=args.service_env,
+            use_host_php_cgi=not args.no_host_php_cgi,
         )
         print(proc.stdout, end="")
         print(proc.stderr, end="")
@@ -632,6 +676,7 @@ def run_php_suite(args: argparse.Namespace) -> int:
         offline=args.offline,
         log_path=log_path,
         service_env=args.service_env,
+        use_host_php_cgi=not args.no_host_php_cgi,
     )
     if not status:
         raise SystemExit("PHP upstream run did not produce any test statuses")
@@ -673,6 +718,7 @@ def run_php_suite(args: argparse.Namespace) -> int:
             "phpdbg_package": args.phpdbg_package,
             "no_php_cgi_shim": args.no_php_cgi_shim,
             "service_env": args.service_env,
+            "no_host_php_cgi": args.no_host_php_cgi,
         },
         "run": {
             "started_at": started_at,
@@ -1056,6 +1102,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-php-cgi-shim",
         action="store_true",
         help="Do not set TEST_PHP_CGI_EXECUTABLE (upstream skips CGI sections).",
+    )
+    run_php.add_argument(
+        "--no-host-php-cgi",
+        action="store_true",
+        help="Use the Wasmer package for the CGI shim even if host php-cgi exists (default: host php-cgi when found).",
     )
     run_php.add_argument(
         "--service-env",

--- a/php_upstream.py
+++ b/php_upstream.py
@@ -55,6 +55,22 @@ def wasmer_guest_env_cli_flags(guest_env: dict[str, str] | None) -> str:
     return " " + " ".join(parts)
 
 
+def resolve_host_php_cgi() -> str | None:
+    """Return host `php-cgi` path if present (Homebrew, Linux packages)."""
+    return shutil.which("php-cgi")
+
+
+def write_host_cli_shim(*, path: Path, executable: str) -> None:
+    """Thin wrapper so run-tests can treat it like another PHP binary (e.g. real php-cgi)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = f"""#!/bin/sh
+set -eu
+exec {sh_quote(executable)} "$@"
+"""
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
 def write_wasmer_php_shim(
     *,
     path: Path,
@@ -86,6 +102,7 @@ def prepare_php_wasmer_shims(
     source_root: Path,
     enable_net: bool,
     service_env: bool,
+    use_host_php_cgi: bool,
 ) -> tuple[Path, Path | None, Path | None]:
     """CLI wrapper is always written; CGI shim is optional; phpdbg only if a package is given."""
     guest_env = dict(SERVICE_ENV_DEFAULTS) if service_env else None
@@ -103,14 +120,19 @@ def prepare_php_wasmer_shims(
     cgi: Path | None = None
     if not no_php_cgi_shim:
         cgi = work_dir / "php-wasmer-cgi"
-        write_wasmer_php_shim(
-            path=cgi,
-            wasmer_bin=wasmer_bin,
-            php_package=cgi_pkg,
-            source_root=source_root,
-            enable_net=enable_net,
-            guest_env=guest_env,
-        )
+        host_cgi = resolve_host_php_cgi() if use_host_php_cgi else None
+        if host_cgi and php_cgi_package is None:
+            # Real CGI SAPI for GET/POST/rfc1867 tests; version may differ from wasm PHP.
+            write_host_cli_shim(path=cgi, executable=host_cgi)
+        else:
+            write_wasmer_php_shim(
+                path=cgi,
+                wasmer_bin=wasmer_bin,
+                php_package=cgi_pkg,
+                source_root=source_root,
+                enable_net=enable_net,
+                guest_env=guest_env,
+            )
 
     phpdbg: Path | None = None
     if phpdbg_package:
@@ -296,6 +318,7 @@ def run_php_debug(
     enable_net: bool,
     offline: bool,
     service_env: bool,
+    use_host_php_cgi: bool,
 ) -> subprocess.CompletedProcess[str]:
     host_php = ensure_host_php()
     cli, cgi, phpdbg = prepare_php_wasmer_shims(
@@ -308,6 +331,7 @@ def run_php_debug(
         source_root=source_root,
         enable_net=enable_net,
         service_env=service_env,
+        use_host_php_cgi=use_host_php_cgi,
     )
     result_file = work_dir / "php-debug-results.tsv"
     result_file.unlink(missing_ok=True)
@@ -342,6 +366,7 @@ def run_php_upstream(
     offline: bool,
     log_path: Path | None = None,
     service_env: bool = False,
+    use_host_php_cgi: bool = True,
 ) -> dict[str, str]:
     host_php = ensure_host_php()
     cli, cgi, phpdbg = prepare_php_wasmer_shims(
@@ -354,6 +379,7 @@ def run_php_upstream(
         source_root=source_root,
         enable_net=enable_net,
         service_env=service_env,
+        use_host_php_cgi=use_host_php_cgi,
     )
     result_file = work_dir / "php-results.tsv"
     result_file.unlink(missing_ok=True)

--- a/php_upstream.py
+++ b/php_upstream.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import os
+import re
+import shutil
+import shlex
+import stat
+import subprocess
+from typing import Any, Iterable
+
+
+PHP_RESULT_MAP = {
+    "PASSED": "PASS",
+    "FAILED": "FAIL",
+    "SKIPPED": "SKIP",
+    "BORKED": "BORK",
+    "WARNED": "WARN",
+    "LEAKED": "LEAK",
+    "XFAILED": "XFAIL",
+    "XLEAKED": "XLEAK",
+}
+
+# Matches credentials in docker-compose.yml (host-published ports).
+SERVICE_ENV_DEFAULTS: dict[str, str] = {
+    "MYSQL_TEST_HOST": "127.0.0.1",
+    "MYSQL_TEST_PORT": "3306",
+    "MYSQL_TEST_USER": "root",
+    "MYSQL_TEST_PASSWD": "compat_root",
+    "MYSQL_TEST_DB": "test",
+    "PGSQL_TEST_CONNSTR": "host=127.0.0.1 port=5432 dbname=test user=postgres password=compat_postgres",
+}
+
+
+def ensure_host_php() -> str:
+    php = shutil.which("php")
+    if php is None:
+        raise RuntimeError("Host php executable not found in PATH; PHP run-tests.php is required as the PHPT runner")
+    return php
+
+
+def sh_quote(value: str | Path) -> str:
+    s = str(value)
+    return "'" + s.replace("'", "'\"'\"'") + "'"
+
+
+def wasmer_guest_env_cli_flags(guest_env: dict[str, str] | None) -> str:
+    """Extra `wasmer run` args so PHP inside the guest sees MYSQL_*, PGSQL_*, etc."""
+    if not guest_env:
+        return ""
+    parts: list[str] = []
+    for key, val in guest_env.items():
+        parts.append(f"--env {sh_quote(f'{key}={val}')}")
+    return " " + " ".join(parts)
+
+
+def write_wasmer_php_shim(
+    *,
+    path: Path,
+    wasmer_bin: str,
+    php_package: str,
+    source_root: Path,
+    enable_net: bool,
+    guest_env: dict[str, str] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    net_arg = " --net" if enable_net else ""
+    env_arg = wasmer_guest_env_cli_flags(guest_env)
+    text = f"""#!/bin/sh
+set -eu
+exec {sh_quote(wasmer_bin)} run{net_arg}{env_arg} --volume {sh_quote(f"{source_root}:{source_root}")} {sh_quote(php_package)} -- "$@"
+"""
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def prepare_php_wasmer_shims(
+    *,
+    work_dir: Path,
+    wasmer_bin: str,
+    php_package: str,
+    php_cgi_package: str | None,
+    phpdbg_package: str | None,
+    no_php_cgi_shim: bool,
+    source_root: Path,
+    enable_net: bool,
+    service_env: bool,
+) -> tuple[Path, Path | None, Path | None]:
+    """CLI wrapper is always written; CGI shim is optional; phpdbg only if a package is given."""
+    guest_env = dict(SERVICE_ENV_DEFAULTS) if service_env else None
+    cli = work_dir / "php-wasmer"
+    write_wasmer_php_shim(
+        path=cli,
+        wasmer_bin=wasmer_bin,
+        php_package=php_package,
+        source_root=source_root,
+        enable_net=enable_net,
+        guest_env=guest_env,
+    )
+
+    cgi_pkg = php_cgi_package or php_package
+    cgi: Path | None = None
+    if not no_php_cgi_shim:
+        cgi = work_dir / "php-wasmer-cgi"
+        write_wasmer_php_shim(
+            path=cgi,
+            wasmer_bin=wasmer_bin,
+            php_package=cgi_pkg,
+            source_root=source_root,
+            enable_net=enable_net,
+            guest_env=guest_env,
+        )
+
+    phpdbg: Path | None = None
+    if phpdbg_package:
+        phpdbg = work_dir / "php-wasmer-phpdbg"
+        write_wasmer_php_shim(
+            path=phpdbg,
+            wasmer_bin=wasmer_bin,
+            php_package=phpdbg_package,
+            source_root=source_root,
+            enable_net=enable_net,
+            guest_env=guest_env,
+        )
+
+    return cli, cgi, phpdbg
+
+
+def php_runtests_extra_env(
+    *,
+    cgi_shim: Path | None,
+    phpdbg_shim: Path | None,
+    service_env: bool,
+) -> dict[str, str]:
+    extra: dict[str, str] = {}
+    if cgi_shim is not None:
+        extra["TEST_PHP_CGI_EXECUTABLE"] = str(cgi_shim)
+    if phpdbg_shim is not None:
+        extra["TEST_PHPDBG_EXECUTABLE"] = str(phpdbg_shim)
+    if service_env:
+        extra.update(SERVICE_ENV_DEFAULTS)
+    return extra
+
+
+def normalize_php_test_name(source_root: Path, name: str) -> str:
+    if name.startswith("# "):
+        return name
+    path = Path(name)
+    try:
+        return path.resolve().relative_to(source_root.resolve()).as_posix()
+    except ValueError:
+        return name
+
+
+def parse_php_results(source_root: Path, result_file: Path) -> dict[str, str]:
+    if not result_file.exists():
+        return {}
+
+    status: dict[str, str] = {}
+    for line in result_file.read_text(errors="replace").splitlines():
+        if not line.strip():
+            continue
+        raw_status, _, raw_name = line.partition("\t")
+        if not raw_name:
+            continue
+        mapped = PHP_RESULT_MAP.get(raw_status.strip(), raw_status.strip())
+        name = normalize_php_test_name(source_root, raw_name.strip())
+        status[name] = mapped
+    return dict(sorted(status.items()))
+
+
+def php_package_version(*, wasmer_bin: str, php_package: str, enable_net: bool) -> str:
+    cmd = [wasmer_bin, "run"]
+    if enable_net:
+        cmd.append("--net")
+    cmd.extend([php_package, "--", "-r", "echo PHP_VERSION;"])
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        return "unknown"
+    return proc.stdout.strip() or "unknown"
+
+
+def php_loaded_extensions(*, wasmer_bin: str, php_package: str, enable_net: bool) -> list[str]:
+    cmd = [wasmer_bin, "run"]
+    if enable_net:
+        cmd.append("--net")
+    cmd.extend([php_package, "--", "-r", "echo implode(PHP_EOL, get_loaded_extensions());"])
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        return []
+    return sorted(line.strip() for line in proc.stdout.splitlines() if line.strip())
+
+
+def php_wasmer_runtime_probe(*, wasmer_bin: str, php_package: str, enable_net: bool) -> dict[str, Any]:
+    """Best-effort facts about the tested Wasmer PHP (root, SAPI)."""
+    cmd_base = [wasmer_bin, "run"]
+    if enable_net:
+        cmd_base.append("--net")
+
+    probe = (
+        "$u = function_exists('posix_geteuid') ? posix_geteuid() : null; "
+        "echo json_encode(['posix_geteuid' => $u, 'sapi' => PHP_SAPI]);"
+    )
+    proc = subprocess.run(
+        [*cmd_base, php_package, "--", "-r", probe],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    out: dict[str, Any] = {"raw_stdout": (proc.stdout or "").strip(), "returncode": proc.returncode}
+    if proc.returncode == 0 and proc.stdout.strip():
+        try:
+            parsed = json.loads(proc.stdout.strip())
+            if isinstance(parsed, dict):
+                out.update(parsed)
+        except json.JSONDecodeError:
+            pass
+    uid = out.get("posix_geteuid")
+    out["runs_as_root"] = uid == 0
+    out["root_skip_tests_note"] = (
+        "Upstream mysqli and other tests skip when posix_geteuid() is 0; "
+        "Wasmer WASI PHP reports euid 0 — those skips cannot be removed from compat-tests alone."
+        if out.get("runs_as_root")
+        else None
+    )
+    return out
+
+
+def phpt_inventory(source_root: Path) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for path in source_root.rglob("*.phpt"):
+        rel = path.relative_to(source_root)
+        if rel.parts[0] == "ext" and len(rel.parts) > 1:
+            key = f"ext/{rel.parts[1]}"
+        elif rel.parts[0] == "sapi" and len(rel.parts) > 1:
+            key = f"sapi/{rel.parts[1]}"
+        else:
+            key = rel.parts[0]
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+
+def php_source_version(source_root: Path) -> str:
+    version_header = source_root / "main" / "php_version.h"
+    if not version_header.exists():
+        return "unknown"
+    match = re.search(r'#define PHP_VERSION "([^"]+)"', version_header.read_text(errors="replace"))
+    return match.group(1) if match else "unknown"
+
+
+def php_test_command(
+    *,
+    host_php: str,
+    source_root: Path,
+    wrapper: Path,
+    result_file: Path,
+    timeout: int,
+    jobs: int | None,
+    offline: bool,
+    tests: Iterable[str] = (),
+) -> list[str]:
+    cmd = [
+        host_php,
+        "-d",
+        "error_reporting=E_ALL & ~E_DEPRECATED",
+        str(source_root / "run-tests.php"),
+        "-q",
+        "-p",
+        str(wrapper),
+        "-n",
+        "--set-timeout",
+        str(timeout),
+        "-W",
+        str(result_file),
+    ]
+    if jobs and jobs > 1:
+        cmd.append(f"-j{jobs}")
+    if offline:
+        cmd.append("--offline")
+    cmd.extend(tests)
+    return cmd
+
+
+def run_php_debug(
+    *,
+    wasmer_bin: str,
+    php_package: str,
+    php_cgi_package: str | None,
+    phpdbg_package: str | None,
+    no_php_cgi_shim: bool,
+    source_root: Path,
+    work_dir: Path,
+    test_name: str,
+    timeout: int,
+    enable_net: bool,
+    offline: bool,
+    service_env: bool,
+) -> subprocess.CompletedProcess[str]:
+    host_php = ensure_host_php()
+    cli, cgi, phpdbg = prepare_php_wasmer_shims(
+        work_dir=work_dir,
+        wasmer_bin=wasmer_bin,
+        php_package=php_package,
+        php_cgi_package=php_cgi_package,
+        phpdbg_package=phpdbg_package,
+        no_php_cgi_shim=no_php_cgi_shim,
+        source_root=source_root,
+        enable_net=enable_net,
+        service_env=service_env,
+    )
+    result_file = work_dir / "php-debug-results.tsv"
+    result_file.unlink(missing_ok=True)
+    cmd = php_test_command(
+        host_php=host_php,
+        source_root=source_root,
+        wrapper=cli,
+        result_file=result_file,
+        timeout=timeout,
+        jobs=None,
+        offline=offline,
+        tests=[test_name],
+    )
+    child_env = os.environ.copy()
+    child_env.update(php_runtests_extra_env(cgi_shim=cgi, phpdbg_shim=phpdbg, service_env=service_env))
+    print(shlex.join(cmd), flush=True)
+    return subprocess.run(cmd, cwd=source_root, text=True, capture_output=True, env=child_env)
+
+
+def run_php_upstream(
+    *,
+    wasmer_bin: str,
+    php_package: str,
+    php_cgi_package: str | None,
+    phpdbg_package: str | None,
+    no_php_cgi_shim: bool,
+    source_root: Path,
+    work_dir: Path,
+    timeout: int,
+    jobs: int | None,
+    enable_net: bool,
+    offline: bool,
+    log_path: Path | None = None,
+    service_env: bool = False,
+) -> dict[str, str]:
+    host_php = ensure_host_php()
+    cli, cgi, phpdbg = prepare_php_wasmer_shims(
+        work_dir=work_dir,
+        wasmer_bin=wasmer_bin,
+        php_package=php_package,
+        php_cgi_package=php_cgi_package,
+        phpdbg_package=phpdbg_package,
+        no_php_cgi_shim=no_php_cgi_shim,
+        source_root=source_root,
+        enable_net=enable_net,
+        service_env=service_env,
+    )
+    result_file = work_dir / "php-results.tsv"
+    result_file.unlink(missing_ok=True)
+    cmd = php_test_command(
+        host_php=host_php,
+        source_root=source_root,
+        wrapper=cli,
+        result_file=result_file,
+        timeout=timeout,
+        jobs=jobs,
+        offline=offline,
+    )
+
+    print("+", shlex.join(cmd), flush=True)
+    child_env = os.environ.copy()
+    extra = php_runtests_extra_env(cgi_shim=cgi, phpdbg_shim=phpdbg, service_env=service_env)
+    child_env.update(extra)
+    log = log_path.open("a") if log_path is not None else None
+    try:
+        if log is not None:
+            log.write("===== PHP upstream run =====\n")
+            log.write("+ " + shlex.join(cmd) + "\n")
+            if extra:
+                log.write(
+                    "env (compat-tests): "
+                    + shlex.join([f"{k}={v}" for k, v in sorted(extra.items())])
+                    + "\n"
+                )
+        proc = subprocess.Popen(
+            cmd,
+            cwd=source_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            env=child_env,
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            print(line, end="", flush=True)
+            if log is not None:
+                log.write(line)
+        exit_code = proc.wait()
+        if log is not None:
+            log.write(f"\n===== PHP upstream exit code: {exit_code} =====\n")
+    finally:
+        if log is not None:
+            log.close()
+
+    return parse_php_results(source_root, result_file)


### PR DESCRIPTION
Proof of concept.

Adds upstream PHP coverage (~20k cases): Zend/engine semantics, tests/language behavior, and extension suites (`mysqli/pdo`, `curl`, `streams`, `opcache`, `session`, `phar`, `xml`, `gd`, etc.) executed through `run-tests.php`.

Result: 11.5k pass, 4.3k fail, 4.1k skip, ~13 min wall (-j12, 60s per-test cap).